### PR TITLE
invoke universal login from login button

### DIFF
--- a/auth0.js
+++ b/auth0.js
@@ -1,0 +1,54 @@
+let auth0 = null;
+const fetchAuthConfig = () => fetch("/auth_config.json");
+
+const configureClient = async () => {
+
+    const response = await fetchAuthConfig();
+    const config = await response.json();
+  
+    auth0 = await createAuth0Client({
+      domain: config.domain,
+      client_id: config.clientId
+    });
+  };
+
+
+  window.onload = async () => {
+    console.log('window.onload');
+    await configureClient();
+    
+    updateUI();
+    const isAuthenticated = await auth0.isAuthenticated();
+
+    if (isAuthenticated) {
+        //show content that should only be shown if the user is authenticated (profile, logout button, etc)
+        console.log('user is authenticated');
+        return;
+    }
+
+    //check for the code and state parameters
+    const query = window.location.search;
+    
+    if (query.includes("code=") && query.includes("state=")) {
+
+        // Process the login state
+        await auth0.handleRedirectCallback();
+    
+        updateUI();
+
+        // Use replaceState to redirect the user away and remove the querystring parameters
+        window.history.replaceState({}, document.title, "/");
+    }
+}
+
+const updateUI = async () => {    
+    const isAuthenticated = await auth0.isAuthenticated();
+    //document.getElementById("btn-logout").disabled = !isAuthenticated;
+    //document.getElementById("btn-login").disabled = isAuthenticated;
+  };
+
+async function universalLogin(){
+    await auth0.loginWithRedirect({
+        redirect_uri: "http://localhost:51761" //needs to be set in auth0 under the makerzero application
+    });
+}

--- a/lib/auth.dart
+++ b/lib/auth.dart
@@ -1,0 +1,7 @@
+@JS()
+library auth;
+
+import 'package:js/js.dart';
+
+@JS('universalLogin')
+external void universalLogin();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,15 +3,10 @@
 /// -----------------------------------
 
 import 'package:flutter/material.dart';
-
 import 'dart:convert';
 import 'package:http/http.dart' as http;
-import 'package:flutter_appauth/flutter_appauth.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
-
-final FlutterAppAuth appAuth = FlutterAppAuth();
-final FlutterSecureStorage secureStorage = const FlutterSecureStorage();
+import 'auth.dart';
 
 /// -----------------------------------
 ///           Auth0 Variables
@@ -31,6 +26,7 @@ class Profile extends StatelessWidget {
   final logoutAction;
   final String name;
   final String picture;
+  
 
   Profile(this.logoutAction, this.name, this.picture);
 
@@ -82,9 +78,10 @@ class Login extends StatelessWidget {
       children: <Widget>[
         RaisedButton(
           onPressed: () {
-            loginAction();
+            //loginAction();
+            universalLogin();
           },
-          child: Text('Login'),
+          child: Text('Universal Login'),
         ),
         Text(loginError ?? ''),
       ],
@@ -133,7 +130,7 @@ class _MyAppState extends State<MyApp> {
               ? CircularProgressIndicator()
               : isLoggedIn
                   ? Profile(logoutAction, name, picture)
-                  : Login(loginAction, errorMessage),
+                  : Login(loginAction, errorMessage), 
         ),
       ),
     );
@@ -173,6 +170,7 @@ class _MyAppState extends State<MyApp> {
     });
 
     try {
+      /*
       final AuthorizationTokenResponse result =
           await appAuth.authorizeAndExchangeCode(
         AuthorizationTokenRequest(
@@ -183,12 +181,12 @@ class _MyAppState extends State<MyApp> {
           // promptValues: ['login']
         ),
       );
+      */
 
-      final idToken = parseIdToken(result.idToken);
-      final profile = await getUserDetails(result.accessToken);
+      final idToken = null; //parseIdToken(result.idToken);
+      final profile = null; //await getUserDetails(result.accessToken);
 
-      await secureStorage.write(
-          key: 'refresh_token', value: result.refreshToken);
+      //await secureStorage.write(key: 'refresh_token', value: result.refreshToken);
 
       setState(() {
         isBusy = false;
@@ -208,7 +206,7 @@ class _MyAppState extends State<MyApp> {
   }
 
   void logoutAction() async {
-    await secureStorage.delete(key: 'refresh_token');
+    //await secureStorage.delete(key: 'refresh_token');
     setState(() {
       isLoggedIn = false;
       isBusy = false;
@@ -222,25 +220,31 @@ class _MyAppState extends State<MyApp> {
   }
 
   void initAction() async {
-    final storedRefreshToken = await secureStorage.read(key: 'refresh_token');
-    if (storedRefreshToken == null) return;
+    
+    //final storedRefreshToken = await secureStorage.read(key: 'refresh_token');
+    //if (storedRefreshToken == null) return;
 
+    /*
     setState(() {
       isBusy = true;
     });
 
     try {
-      final response = await appAuth.token(TokenRequest(
+      final response = null;
+      
+      /*
+      await appAuth.token(TokenRequest(
         AUTH0_CLIENT_ID,
         AUTH0_REDIRECT_URI,
         issuer: AUTH0_ISSUER,
         refreshToken: storedRefreshToken,
       ));
+      */
 
-      final idToken = parseIdToken(response.idToken);
-      final profile = await getUserDetails(response.accessToken);
+      final idToken = null;  //parseIdToken(response.idToken);
+      final profile = null; //await getUserDetails(response.accessToken);
 
-      secureStorage.write(key: 'refresh_token', value: response.refreshToken);
+      //secureStorage.write(key: 'refresh_token', value: response.refreshToken);
 
       setState(() {
         isBusy = false;
@@ -252,5 +256,7 @@ class _MyAppState extends State<MyApp> {
       print('error on refresh token: $e - stack: $s');
       logoutAction();
     }
+    */
   }
+
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -62,20 +62,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_appauth:
-    dependency: "direct main"
-    description:
-      name: flutter_appauth
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.9.2+5"
-  flutter_appauth_platform_interface:
-    dependency: transitive
-    description:
-      name: flutter_appauth_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -102,6 +88,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.4"
+  js:
+    dependency: "direct main"
+    description:
+      name: js
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.2"
   matcher:
     dependency: transitive
     description:
@@ -115,7 +108,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0-nullsafety.4"
   path:
     dependency: transitive
     description:
@@ -130,13 +123,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.2"
-  plugin_platform_interface:
-    dependency: transitive
-    description:
-      name: plugin_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -213,5 +199,5 @@ packages:
     source: hosted
     version: "0.1.2"
 sdks:
-  dart: ">=2.10.0-110 <=2.11.0-207.0.dev"
+  dart: ">=2.10.0-110 <=2.11.0-213.1.beta"
   flutter: ">=1.20.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,9 +24,10 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^0.12.1
-  flutter_appauth: ^0.9.1
   flutter_secure_storage: ^3.3.3
   universal_io: ^1.0.1
+  js:
+  
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/web/auth_config.json
+++ b/web/auth_config.json
@@ -1,0 +1,4 @@
+{
+    "domain": "makerzero-dev.us.auth0.com",
+    "clientId": "2n2CRkCsRlNM2AL1v9Sxi28rwc0Rg73T"
+}

--- a/web/index.html
+++ b/web/index.html
@@ -26,6 +26,10 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
+  <!-- -->
+  <script src="https://cdn.auth0.com/js/auth0-spa-js/1.9/auth0-spa-js.production.js"></script>    
+
+  <script src="/auth0.js" type="application/javascript"></script>
   <title>flutterauth0demo</title>
   <link rel="manifest" href="manifest.json">
 </head>


### PR DESCRIPTION
this code is rough, but it shows how to call a js function from dart which is needed to invoke universal login. It still needs some work to handle when the user is redirected after login (showing logout button, showing profile, etc). I think that can be done completely in javascript (so we can follow the SPA auth0 example) if we add the necessary interop code in dart so that we can see dart objects in javascript.

this is the package I'm using to handle the javascript interop: https://pub.dev/packages/js